### PR TITLE
feat: 添加 TTS 文本语言自动检测

### DIFF
--- a/_conf_schema.json
+++ b/_conf_schema.json
@@ -102,13 +102,15 @@
                     "zh",
                     "en",
                     "ja",
-                    "ko"
+                    "ko",
+                    "auto"
                 ],
                 "labels": [
                     "中文",
                     "英语",
                     "日语",
-                    "韩语"
+                    "韩语",
+                    "多语种混合(自动)"
                 ],
                 "default": "zh"
             },
@@ -298,6 +300,12 @@
                 "description": "使用 LLM 判断情感",
                 "type": "bool",
                 "hint": "开启后，将使用 LLM 模型判断当前文本的情绪，从而改变语音的情绪参数。若关闭， 则使用情绪条目的触发词来匹配情绪",
+                "default": false
+            },
+            "auto_detect_lang": {
+                "description": "自动判断文本语言",
+                "type": "bool",
+                "hint": "开启后，将使用配置的 LLM 提供商为每次 TTS 请求判断文本语言，并用 en、zh、ja、ko 之一覆盖 default_params.text_lang；关闭时保留手动 text_lang 设置，包括 auto。",
                 "default": false
             },
             "provider_id": {

--- a/core/config.py
+++ b/core/config.py
@@ -127,6 +127,7 @@ class ModelConfig(ConfigNode):
 
 class JudgeConfig(ConfigNode):
     enabled_llm: bool
+    auto_detect_lang: bool
     provider_id: str
 
 
@@ -151,6 +152,8 @@ class PluginConfig(ConfigNode):
     def __init__(self, cfg: AstrBotConfig, context: Context):
         super().__init__(cfg)
         self.context = context
+        if "auto_detect_lang" not in self.judge.raw_data():
+            self.judge.auto_detect_lang = False
 
         self.data_dir = StarTools.get_data_dir(self._plugin_name)
         self.plugin_dir = Path(get_astrbot_plugin_path()) / self._plugin_name

--- a/core/language.py
+++ b/core/language.py
@@ -1,0 +1,147 @@
+from __future__ import annotations
+
+import json
+import re
+from typing import Any
+
+from astrbot.api import logger
+from astrbot.core.platform.astr_message_event import AstrMessageEvent
+
+from .config import PluginConfig
+
+
+class LanguageJudger:
+    EXTRA_KEY = "gsv_text_lang"
+    ALLOWED_LANGS = {"en", "zh", "ja", "ko"}
+    ALIASES = {
+        "zh": "zh",
+        "cn": "zh",
+        "chinese": "zh",
+        "中文": "zh",
+        "汉语": "zh",
+        "漢語": "zh",
+        "普通话": "zh",
+        "mandarin": "zh",
+        "en": "en",
+        "eng": "en",
+        "english": "en",
+        "英文": "en",
+        "英语": "en",
+        "英語": "en",
+        "ja": "ja",
+        "jp": "ja",
+        "japanese": "ja",
+        "日文": "ja",
+        "日语": "ja",
+        "日語": "ja",
+        "日本語": "ja",
+        "ko": "ko",
+        "kr": "ko",
+        "korean": "ko",
+        "韩文": "ko",
+        "韩语": "ko",
+        "韓文": "ko",
+        "韓語": "ko",
+        "한국어": "ko",
+    }
+
+    def __init__(self, config: PluginConfig):
+        self.cfg = config
+
+    async def judge_language(
+        self,
+        event: AstrMessageEvent,
+        *,
+        text: str = "",
+    ) -> str | None:
+        """
+        使用 LLM 判断 TTS 文本语言。
+
+        失败或无法判断时返回 None，由调用方继续使用默认 text_lang。
+        """
+        cached = event.get_extra(self.EXTRA_KEY)
+        if isinstance(cached, str):
+            lang = self._normalize_lang(cached)
+            if lang:
+                logger.debug(f"复用文本语言标签: {lang}")
+                return lang
+
+        if not text.strip():
+            return None
+
+        try:
+            provider = self.cfg.get_judge_provider(event.unified_msg_origin)
+            system_prompt, prompt = self._build_prompt(text)
+            resp = await provider.text_chat(
+                system_prompt=system_prompt,
+                prompt=prompt,
+            )
+
+            lang = self._parse_llm_response(resp.completion_text)
+            if not lang:
+                logger.debug("文本语言判断结果为空，使用默认配置")
+                return None
+
+            logger.debug(f"文本语言判断结果: {lang}")
+            event.set_extra(self.EXTRA_KEY, lang)
+            return lang
+
+        except Exception as e:
+            logger.exception(f"文本语言判断失败: {e}")
+            return None
+
+    def _build_prompt(self, text: str) -> tuple[str, str]:
+        system_prompt = (
+            "你是一个文本语言分类器。\n"
+            "只根据用户提供的文本本身判断语言，不要根据上下文、用户偏好或默认语言推断。\n"
+            "只能返回 en、zh、ja、ko 之一，或在无法明确判断时返回 null。\n"
+            "混合语言文本请选择 en、zh、ja、ko 中占主导的语言。\n"
+            "如果没有支持语言明显占主导，请返回 null，不要返回 auto。\n"
+            "不要返回 yue、auto_yue、all_zh、all_ja、all_yue、all_ko 等标签。\n"
+            "粤语文本一般归为 zh；除非明显不适合，否则不要返回 null。\n"
+            "请严格按照 JSON 格式输出，不要包含任何多余内容。\n"
+            '输出示例：{"text_lang":"zh"} 或 {"text_lang":null}'
+        )
+        prompt = f"文本内容：{text}"
+        return system_prompt, prompt
+
+    def _parse_llm_response(self, text: str) -> str | None:
+        data = self._loads_json(text)
+        if not isinstance(data, dict):
+            raise ValueError(f"LLM JSON 不是对象: {data}")
+
+        lang = data.get("text_lang")
+        if lang is None:
+            return None
+        if not isinstance(lang, str):
+            raise ValueError(f"LLM JSON text_lang 字段非法: {data}")
+
+        normalized = self._normalize_lang(lang)
+        if not normalized:
+            raise ValueError(f"LLM 返回不支持的语言标签: {lang}")
+        return normalized
+
+    def _loads_json(self, text: str) -> Any:
+        content = text.strip()
+        fenced = re.fullmatch(r"```(?:json)?\s*(.*?)\s*```", content, re.DOTALL)
+        if fenced:
+            content = fenced.group(1).strip()
+
+        try:
+            return json.loads(content)
+        except json.JSONDecodeError as e:
+            decoder = json.JSONDecoder()
+            for match in re.finditer(r"\{", content):
+                try:
+                    value, _ = decoder.raw_decode(content[match.start() :])
+                    return value
+                except json.JSONDecodeError:
+                    continue
+            raise ValueError(f"LLM 返回非 JSON: {text}") from e
+
+    def _normalize_lang(self, value: str) -> str | None:
+        lang = value.strip().lower()
+        lang = self.ALIASES.get(lang, lang)
+        if lang in self.ALLOWED_LANGS:
+            return lang
+        return None

--- a/main.py
+++ b/main.py
@@ -12,6 +12,7 @@ from .core.client import GSVApiClient, GSVRequestResult
 from .core.config import PluginConfig
 from .core.emotion import EmotionJudger
 from .core.entry import EntryManager
+from .core.language import LanguageJudger
 from .core.local_data import LocalDataManager
 from .core.service import GPTSoVITSService
 
@@ -24,6 +25,7 @@ class GPTSoVITSPlugin(Star):
         self.entry_mgr = EntryManager(self.cfg)
         self.client = GSVApiClient(self.cfg)
         self.judger = EmotionJudger(self.cfg)
+        self.lang_judger = LanguageJudger(self.cfg)
         self.service = GPTSoVITSService(self.cfg, self.client, self.local_data)
 
     async def initialize(self):
@@ -65,6 +67,27 @@ class GPTSoVITSPlugin(Star):
 
         return entry.to_params() if entry else None
 
+    async def _get_request_params(
+        self,
+        event: AstrMessageEvent,
+        text: str,
+        *,
+        use_emotion: bool = True,
+    ) -> dict | None:
+        params = {}
+
+        if use_emotion:
+            emotion_params = await self._get_emotion_params(event, text)
+            if emotion_params:
+                params.update(emotion_params)
+
+        if self.cfg.judge.auto_detect_lang:
+            lang = await self.lang_judger.judge_language(event, text=text)
+            if lang:
+                params["text_lang"] = lang
+
+        return params or None
+
     @filter.on_decorating_result(priority=14)
     async def on_decorating_result(self, event: AstrMessageEvent):
         """消息入口"""
@@ -100,7 +123,7 @@ class GPTSoVITSPlugin(Star):
         if len(combined_text) > cfg.max_msg_len:
             return
 
-        params = await self._get_emotion_params(event, combined_text)
+        params = await self._get_request_params(event, combined_text)
         res = await self.service.inference(combined_text, extra_params=params)
         if not bool(res):
             return
@@ -114,7 +137,8 @@ class GPTSoVITSPlugin(Star):
             return
 
         text = event.message_str.partition(" ")[2]
-        res = await self.service.inference(text)
+        params = await self._get_request_params(event, text, use_emotion=False)
+        res = await self.service.inference(text, extra_params=params)
 
         if not bool(res):
             yield event.plain_result(res.error)
@@ -138,7 +162,7 @@ class GPTSoVITSPlugin(Star):
             message(string): 要讲的话
         """
         try:
-            params = await self._get_emotion_params(event, message)
+            params = await self._get_request_params(event, message)
             res = await self.service.inference(message, extra_params=params)
             if not bool(res):
                 return res.error


### PR DESCRIPTION
## 概要

添加 TTS 文本语言自动检测能力。开启配置后，插件会在语音合成前使用 LLM 判断待合成文本的主要语言，并用判断结果覆盖本次请求的 `text_lang`，减少手动切换中英日韩语言配置的需要。

## 主要改动

- 新增 `judge.auto_detect_lang` 配置项，默认关闭，保持现有行为不变。
- 新增 `LanguageJudger`，通过 LLM 将文本分类为 `zh`、`en`、`ja`、`ko`，无法明确判断时回退到默认配置。
- 语言判断复用现有情感检测的 LLM Provider 配置，与情感检测使用相同的模型 API。
- 支持解析纯 JSON、Markdown fenced JSON，以及响应中夹带 JSON 对象的情况。
- 支持常见语言别名归一化，例如 `中文`、`english`、`日本語`、`한국어` 等。
- 在自动转语音、`说/gsv/GSV` 命令、`gsv_tts` LLM tool 中统一应用语言检测结果。
- 对同一事件的检测结果写入 `event.extra`，避免同一轮流程重复请求 LLM。

## 兼容性

- `auto_detect_lang` 默认值为 `false`，不开启时继续使用原有 `default_params.text_lang`。
- 旧配置缺少该字段时会自动补上默认值并保存。
- LLM 判断失败、返回非法 JSON 或返回不支持的语言标签时，会记录日志并回退到原默认语言配置。

## Summary by Sourcery

为 TTS 请求新增可选的基于 LLM 的自动语言检测功能，并在所有 TTS 入口统一使用检测到的语言，同时默认保持现有行为不变。

新功能：
- 引入 LanguageJudger，通过现有的 judging LLM 将 TTS 文本分类为 zh/en/ja/ko，并按事件缓存结果。
- 新增 judge.auto_detect_lang 配置开关，用于启用或禁用 TTS 文本的自动语言检测。

增强改进：
- 统一构建额外的 TTS 请求参数，使情绪和语言设置在自动 TTS、speak 命令以及 gsv_tts 工具中都能一致生效。
- 确保在插件配置加载过程中，如果缺少 auto_detect_lang 配置项，会使用安全的默认值进行初始化。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add optional LLM-based automatic language detection for TTS requests and apply the detected language across all TTS entry points while keeping existing behavior unchanged by default.

New Features:
- Introduce LanguageJudger to classify TTS text into zh/en/ja/ko via the existing judging LLM and cache results per event.
- Add a judge.auto_detect_lang configuration flag to enable or disable automatic TTS text language detection.

Enhancements:
- Unify construction of extra TTS request parameters so that emotion and language settings are applied consistently in auto-TTS, speak commands, and the gsv_tts tool.
- Ensure missing auto_detect_lang configuration is initialized with a safe default during plugin config loading.

</details>